### PR TITLE
MIDI-145: Tokenizers

### DIFF
--- a/dashboards/midi_review.py
+++ b/dashboards/midi_review.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+from dashboards.quantizer_review import main as quantizer_review
+from dashboards.tokenizer_review import main as tokenizer_review
+
+
+def main():
+    display_mode = st.selectbox("display mode", options=["tokenizer review", "quantizer review"])
+
+    match display_mode:
+        case "quantizer review":
+            quantizer_review()
+        case "tokenizer review":
+            tokenizer_review()
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboards/quantizer_review.py
+++ b/dashboards/quantizer_review.py
@@ -4,7 +4,7 @@ import streamlit_pianoroll
 from fortepyan import MidiPiece
 from datasets import Dataset, load_dataset
 
-from dashboards.quantizer_generator import QuantizerGenerator
+from quantizer_generator import QuantizerGenerator
 
 
 @st.cache_data

--- a/dashboards/tokenizer_review.py
+++ b/dashboards/tokenizer_review.py
@@ -1,0 +1,95 @@
+import yaml
+import streamlit as st
+import streamlit_pianoroll
+from fortepyan import MidiPiece
+from datasets import Dataset, load_dataset
+
+from tokenizer_generator import TokenizerGenerator
+
+
+@st.cache_data
+def load_hf_dataset(dataset_name: str, split: str):
+    return load_dataset(dataset_name, split=split)
+
+
+def select_dataset():
+    dataset_names = ["roszcz/maestro-sustain-v2"]
+    dataset_name = st.selectbox(label="dataset", options=dataset_names)
+
+    dataset = load_hf_dataset(dataset_name=dataset_name, split="test")
+    return dataset
+
+
+def select_record(midi_dataset: Dataset):
+    source_df = midi_dataset.to_pandas()
+    source_df["source"] = source_df["source"].map(lambda source: yaml.safe_load(source))
+    source_df["composer"] = [source["composer"] for source in source_df.source]
+    source_df["title"] = [source["title"] for source in source_df.source]
+
+    composers = source_df.composer.unique()
+
+    selected_composer = st.selectbox(
+        label="Select composer",
+        options=composers,
+        index=3,
+    )
+
+    ids = source_df.composer == selected_composer
+    piece_titles = source_df[ids].title.unique()
+    selected_title = st.selectbox(
+        label="Select title",
+        options=piece_titles,
+    )
+    st.write(selected_title)
+
+    ids = (source_df.composer == selected_composer) & (source_df.title == selected_title)
+    part_df = source_df[ids]
+    part_dataset = midi_dataset.select(part_df.index.values)
+
+    return part_dataset[0]
+
+
+def main():
+    tokenizer_generator = TokenizerGenerator()
+
+    tokenizer_names = tokenizer_generator.name_to_factory_map.keys()
+    tokenizer_name = st.selectbox(label="tokenizer", options=tokenizer_names)
+
+    st.write(tokenizer_generator.tokenizer_info(name=tokenizer_name))
+    with st.form("tokenizer generation"):
+        tokenizer = tokenizer_generator.generate_tokenizer_with_streamlit(tokenizer_name)
+        st.form_submit_button("Run")
+
+    midi_dataset = select_dataset()
+
+    record = select_record(midi_dataset=midi_dataset)
+
+    piece = MidiPiece.from_huggingface(record=record)
+    end = piece.df.start.max()
+
+    fragment_selection_columns = st.columns(2)
+    start = fragment_selection_columns[0].number_input("start", value=0.0)
+    finish = fragment_selection_columns[1].number_input(f"finish [0-{end}]", value=60.0)
+    piece = piece.trim(start, finish)
+
+    tokens = tokenizer.tokenize(piece.df)
+    untokenized_notes = tokenizer.untokenize(tokens=tokens)
+
+    untokenized_piece = MidiPiece(df=untokenized_notes, source=piece.source | {"tokenized": True})
+
+    review_columns = st.columns(2)
+    with review_columns[0]:
+        st.write("Original piece")
+        streamlit_pianoroll.from_fortepyan(piece=piece)
+    with review_columns[1]:
+        st.write("Untokenized piece")
+        streamlit_pianoroll.from_fortepyan(piece=untokenized_piece)
+
+    st.write(f"number of tokens: {len(tokens)}")
+
+    with st.expander(label="tokens"):
+        st.write(tokens)
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboards/tokenizer_review.py
+++ b/dashboards/tokenizer_review.py
@@ -59,6 +59,7 @@ def main():
     with st.form("tokenizer generation"):
         tokenizer = tokenizer_generator.generate_tokenizer_with_streamlit(tokenizer_name)
         st.form_submit_button("Run")
+    st.write(f"vocab size: {tokenizer.vocab_size}")
 
     midi_dataset = select_dataset()
 

--- a/midi_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/midi_tokenizer.py
@@ -6,6 +6,7 @@ import pandas as pd
 class MidiTokenizer:
     def __init__(self):
         self.token_to_id = None
+        self.vocab = []
 
     @abstractmethod
     def tokenize(self, record: dict) -> list[str]:
@@ -14,6 +15,10 @@ class MidiTokenizer:
     @abstractmethod
     def untokenize(self, tokens: list[str]) -> pd.DataFrame:
         raise NotImplementedError("Your encoder needs *untokenize* implementation")
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.vocab)
 
     def decode(self, token_ids: list[int]) -> pd.DataFrame:
         tokens = [self.vocab[token_id] for token_id in token_ids]

--- a/midi_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/midi_tokenizer.py
@@ -21,7 +21,7 @@ class MidiTokenizer:
 
         return df
 
-    def encode(self, record: dict) -> list[int]:
-        tokens = self.tokenize(record)
+    def encode(self, notes: pd.DataFrame) -> list[int]:
+        tokens = self.tokenize(notes)
         token_ids = [self.token_to_id[token] for token in tokens]
         return token_ids

--- a/midi_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/midi_tokenizer.py
@@ -1,0 +1,27 @@
+from abc import abstractmethod
+
+import pandas as pd
+
+
+class MidiTokenizer:
+    def __init__(self):
+        self.token_to_id = None
+
+    @abstractmethod
+    def tokenize(self, record: dict) -> list[str]:
+        raise NotImplementedError("Your encoder needs *tokenize* implementation")
+
+    @abstractmethod
+    def untokenize(self, tokens: list[str]) -> pd.DataFrame:
+        raise NotImplementedError("Your encoder needs *untokenize* implementation")
+
+    def decode(self, token_ids: list[int]) -> pd.DataFrame:
+        tokens = [self.vocab[token_id] for token_id in token_ids]
+        df = self.untokenize(tokens)
+
+        return df
+
+    def encode(self, record: dict) -> list[int]:
+        tokens = self.tokenize(record)
+        token_ids = [self.token_to_id[token] for token in tokens]
+        return token_ids

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -150,7 +150,7 @@ class NoLossTokenizer(MidiTokenizer):
         current_velocity = 0
         for token in tokens:
             if "s" in token:
-                dt: float = eval(token[:-1])
+                dt: float = self.token_to_dt(token)
                 current_time += dt
             if "VELOCITY" in token:
                 # velocity should always be right before NOTE_ON token

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -41,7 +41,7 @@ class NoLossTokenizer(MidiTokenizer):
             self.vocab.append(f"VELOCITY_{vel}")
 
         time_vocab = self._time_vocab()
-        self.max_time_token = time_vocab[-1]  # Maximum time token
+        self.max_time_token: float = eval(time_vocab[-1][:-1])  # Maximum time token
         return self.vocab
 
     def _time_vocab(self):

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -64,12 +64,12 @@ class NoLossTokenizer(MidiTokenizer):
         """
         note_on_df: pd.DataFrame = notes.loc[:, ["start", "pitch", "velocity_bin"]]
         note_off_df: pd.DataFrame = notes.loc[:, ["end", "pitch"]]
-        
+
         note_off_df["time"] = note_off_df["end"]
         note_off_df["event"] = "NOTE_OFF"
         note_on_df["time"] = note_on_df["start"]
         note_on_df["event"] = "NOTE_ON"
-        
+
         note_on_events = note_on_df.to_dict(orient="records")
         note_off_events = note_off_df.to_dict(orient="records")
         note_events = note_on_events + note_off_events

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -40,15 +40,19 @@ class NoLossTokenizer(MidiTokenizer):
         for vel in range(self.n_velocity_bins):
             self.vocab.append(f"VELOCITY_{vel}")
 
+        time_vocab = self._time_vocab()
+        self.max_time_token = time_vocab[-1]  # Maximum time token
+        return self.vocab
+
+    def _time_vocab(self):
+        time_vocab = []
         token = self.eps
 
         # Generate time tokens with exponential distribution
         while token < 1:
-            self.vocab.append(f"{token}s")
+            time_vocab.append(f"{token}s")
             token *= 2
-
-        self.max_time_token = token  # Maximum time token
-        return self.vocab
+        return time_vocab
 
     def quantize_frame(self, df: pd.DataFrame):
         df["velocity_bin"] = np.digitize(df.velocity, self.velocity_bin_edges) - 1

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -151,7 +151,7 @@ class NoLossTokenizer(MidiTokenizer):
         current_velocity = 0
         for token in tokens:
             if "s" in token:
-                dt: float = self.token_to_dt(token)
+                dt: float = self.token_to_dt[token]
                 current_time += dt
             if "VELOCITY" in token:
                 # velocity should always be right before NOTE_ON token

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -1,0 +1,123 @@
+from midi_tokenizers.midi_tokenizer import MidiTokenizer
+import pandas as pd
+from tqdm import tqdm
+
+
+class NoLossTokenizer(MidiTokenizer):
+    def __init__(self, eps: float = 0.001, ):
+        super().__init__()
+        self.eps = eps
+        self.specials = ["<CLS>"]
+        self.vocab = self._build_vocab()
+        self.token_to_id = {token: it for it, token in enumerate(self.vocab)}
+        
+    def __rich_repr__(self):
+        yield "NoLossTokenizer"
+        yield "eps", self.eps
+        yield "vocab_size", self.vocab_size
+    
+    def _build_vocab(self):
+        self.vocab = list(self.specials)
+
+        for pitch in range(21, 109):
+            self.vocab.append(f"NOTE_ON_{pitch}")
+            self.vocab.append(f"NOTE_OFF_{pitch}")
+        for vel in range(128):
+            self.vocab.append(f"VELOCITY_{vel}")
+        token = self.eps
+        while token < 1:
+            self.vocab.append(f"{token}s")
+            token *= 2
+        self.max_time_token = token
+        return self.vocab
+
+    @staticmethod
+    def _notes_to_event_df(notes: pd.DataFrame):
+        note_on_events: pd.DataFrame = notes.loc[:, ["start", "pitch", "velocity"]]
+        note_off_events: pd.DataFrame = notes.loc[:, ["end", "pitch"]]
+
+        note_off_events["time"] = note_off_events["end"]
+        note_off_events["event"] = "NOTE_OFF"
+        note_on_events["time"] = note_on_events["start"]
+        note_on_events["event"] = "NOTE_ON"
+        
+        note_events: pd.DataFrame = pd.concat([note_on_events, note_off_events], axis=0)
+        note_events = note_events.sort_values(by="time")
+        
+        return note_events
+    
+    def tokenize(self, notes: pd.DataFrame) -> list[str]:
+        tokens = []
+        previous_time = 0
+        current_step = self.max_time_token
+        
+        note_events = self._notes_to_event_df(notes=notes)
+
+        
+        for _, current_event in note_events.iterrows():
+            current_step = self.max_time_token
+            dt = current_event["time"] - previous_time
+            filling_dt = 0
+            while True:
+                if filling_dt + current_step > dt:
+                    current_step /= 2
+                else:
+                    tokens.append(f"{current_step}s")
+                    filling_dt += current_step
+                
+                if dt - filling_dt < self.eps:
+                    break
+            if current_event["event"] == "NOTE_ON":
+                tokens.append(f"VELOCITY_{current_event['velocity']}")
+            tokens.append(f"{current_event['event']}_{current_event['pitch']}")
+            previous_time = current_event["time"]
+
+        return tokens
+
+    def untokenize(self, tokens: list[str]) -> pd.DataFrame:
+        note_on_events = []
+        note_off_events = []
+        
+        current_time = 0
+        current_velocity = 0
+        for token in tokens:
+            if "s" in token:
+                dt: float = eval(token[:-1])
+                current_time += dt
+            if "VELOCITY" in token:
+                # velocity should always be right before NOTE_ON token
+                current_velocity: int = eval(token[9:])
+            if "NOTE_ON" in token:
+                note = {
+                    "pitch": eval(token[8:]),
+                    "start": current_time,
+                    "velocity": current_velocity,
+                }
+                note_on_events.append(note)
+            if "NOTE_OFF" in token:
+                note = {
+                    "pitch": eval(token[9:]),
+                    "end": current_time,
+                }
+                note_off_events.append(note)
+
+        # Both should be sorted by time right now
+        note_on_events = pd.DataFrame(note_on_events)
+        note_off_events = pd.DataFrame(note_off_events)
+        
+        # So if we sort them by pitch ...
+        note_on_events = note_on_events.sort_values(by="pitch")
+        note_off_events = note_off_events.sort_values(by="pitch")
+
+        note_off_events = note_off_events.reset_index(drop=True)
+        note_on_events =  note_on_events.reset_index(drop=True)
+        
+        # we get pairs of note on and note off events for each key-press
+        notes = note_on_events
+        notes["end"] = note_off_events["end"]
+        
+        notes = notes.sort_values(by="start")
+        notes = notes.reset_index(drop=True)
+
+        return notes
+        

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -25,6 +25,10 @@ class NoLossTokenizer(MidiTokenizer):
         yield "eps", self.eps
         yield "vocab_size", self.vocab_size
 
+    @property
+    def vocab_size(self) -> int:
+        return len(self.vocab)
+
     def _build_vocab(self):
         self.vocab = list(self.specials)
 

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -46,8 +46,11 @@ class NoLossTokenizer(MidiTokenizer):
             self.token_to_velocity_bin |= {f"VELOCITY_{vel}": vel}
 
         time_vocab, token_to_dt = self._time_vocab()
+        self.vocab += time_vocab
+
         self.token_to_dt = token_to_dt
-        self.max_time_value = float(time_vocab[-1][:-1])  # Maximum time
+        self.max_time_value = self.token_to_dt[time_vocab[-1]]  # Maximum time
+
         return self.vocab, self.token_to_dt
 
     def _time_vocab(self):

--- a/midi_tokenizers/no_loss_tokenizer.py
+++ b/midi_tokenizers/no_loss_tokenizer.py
@@ -14,7 +14,7 @@ class NoLossTokenizer(MidiTokenizer):
         self.eps = eps
         self.n_velocity_bins = n_velocity_bins
         self.specials = ["<CLS>"]
-        self.vocab, self.token_to_dt = self._build_vocab()
+        self._build_vocab()
         self.token_to_id = {token: it for it, token in enumerate(self.vocab)}
 
         self.velocity_bin_edges = np.linspace(0, 127, num=n_velocity_bins, endpoint=True).astype(int)
@@ -50,8 +50,6 @@ class NoLossTokenizer(MidiTokenizer):
 
         self.token_to_dt = token_to_dt
         self.max_time_value = self.token_to_dt[time_vocab[-1]]  # Maximum time
-
-        return self.vocab, self.token_to_dt
 
     def _time_vocab(self):
         time_vocab = []

--- a/midi_tokenizers/one_time_tokenizer.py
+++ b/midi_tokenizers/one_time_tokenizer.py
@@ -10,4 +10,4 @@ class OneTimeTokenizer(NoLossTokenizer):
         super().__init__(eps=eps, n_velocity_bins=n_velocity_bins)
 
     def _time_vocab(self):
-        return [self.eps]
+        return [f"{self.eps}s"]

--- a/midi_tokenizers/one_time_tokenizer.py
+++ b/midi_tokenizers/one_time_tokenizer.py
@@ -1,0 +1,13 @@
+from midi_tokenizers.no_loss_tokenizer import NoLossTokenizer
+
+
+class OneTimeTokenizer(NoLossTokenizer):
+    def __init__(
+        self,
+        eps: float = 0.001,
+        n_velocity_bins: int = 128,
+    ):
+        super().__init__(eps=eps, n_velocity_bins=n_velocity_bins)
+
+    def _time_vocab(self):
+        return [self.eps]

--- a/midi_tokenizers/one_time_tokenizer.py
+++ b/midi_tokenizers/one_time_tokenizer.py
@@ -10,4 +10,4 @@ class OneTimeTokenizer(NoLossTokenizer):
         super().__init__(eps=eps, n_velocity_bins=n_velocity_bins)
 
     def _time_vocab(self):
-        return [f"{self.eps}s"]
+        return [f"{self.eps}s"], {f"{self.eps}s": self.eps}

--- a/midi_tokenizers/quantized_midi_tokenizer.py
+++ b/midi_tokenizers/quantized_midi_tokenizer.py
@@ -1,0 +1,71 @@
+import itertools
+
+import pandas as pd
+
+from quantizer_generator import QuantizerGenerator
+from midi_tokenizers.midi_tokenizer import MidiTokenizer
+
+
+class QuantizedMidiTokenizer(MidiTokenizer):
+    def __init__(self, quantization_cfg: dict, quantizer_name: str):
+        super().__init__()
+        quantizer_generator = QuantizerGenerator()
+
+        self.quantizer = quantizer_generator.generate_quantizer(
+            quantizer_name,
+            quantization_cfg=quantization_cfg,
+        )
+        self.quantization_cfg = quantization_cfg
+        self.keys = self.quantizer.keys
+        self.specials = ["<CLS>"]
+
+        self.vocab = list(self.specials)
+
+        # add midi tokens to vocab
+        self._build_vocab()
+        self.token_to_id = {token: it for it, token in enumerate(self.vocab)}
+
+    def __rich_repr__(self):
+        yield "QuantizedMidiTokenizer"
+        yield "vocab_size", self.vocab_size
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.vocab)
+
+    def _build_vocab(self):
+        src_iterators_product = itertools.product(
+            # Always include 88 pitches
+            range(21, 109),
+            range(self.quantization_cfg["dstart"]),
+            range(self.quantization_cfg["duration"]),
+            range(self.quantization_cfg["velocity"]),
+        )
+
+        for pitch, dstart, duration, velocity in src_iterators_product:
+            key = f"{pitch}-{dstart}-{duration}-{velocity}"
+            self.vocab.append(key)
+
+    def tokenize(self, notes: pd.DataFrame) -> list[str]:
+        tokens = []
+        n_samples = len(notes[self.keys[0]])
+        for idx in range(n_samples):
+            token = "-".join([f"{notes[key][idx]:0.0f}" for key in self.keys])
+            tokens.append(token)
+
+        return tokens
+
+    def untokenize(self, tokens: list[str]) -> pd.DataFrame:
+        notes = []
+        for token in tokens:
+            if token in self.specials:
+                continue
+
+            values_txt = token.split("-")
+            values = [eval(txt) for txt in values_txt]
+            notes.append(values)
+
+        notes = pd.DataFrame(notes, columns=self.keys)
+        notes = self.quantizer.apply_quantization(df=notes)
+
+        return notes

--- a/quantizer_generator.py
+++ b/quantizer_generator.py
@@ -104,3 +104,7 @@ class QuantizerGenerator:
         quantization_cfg = factory.select_parameters()
 
         return factory.create_quantizer(quantization_cfg)
+
+    def generate_quantizer(self, name: str, quantization_cfg: dict) -> MidiQuantizer:
+        factory = self.name_to_factory_map[name]
+        return factory.create_quantizer(quantization_cfg)

--- a/quantizers/absolute_time_quantizer.py
+++ b/quantizers/absolute_time_quantizer.py
@@ -1,7 +1,8 @@
 import yaml
 import numpy as np
 import pandas as pd
-from quantizer import MidiQuantizer
+
+from quantizers.quantizer import MidiQuantizer
 
 
 class AbsoluteTimeQuantizer(MidiQuantizer):

--- a/quantizers/absolute_time_quantizer.py
+++ b/quantizers/absolute_time_quantizer.py
@@ -12,6 +12,7 @@ class AbsoluteTimeQuantizer(MidiQuantizer):
         n_start_bins: int = 625,
         sequence_duration: float = 20.0,
     ):
+        self.keys = ["pitch", "start_bin", "duration_bin", "velocity_bin"]
         self.n_velocity_bins = n_velocity_bins
         self.n_duration_bins = n_duration_bins
         self.n_start_bins = n_start_bins

--- a/quantizers/relative_time_quantizer.py
+++ b/quantizers/relative_time_quantizer.py
@@ -11,6 +11,7 @@ class RelativeTimeQuantizer(MidiQuantizer):
         n_duration_bins: int = 3,
         n_velocity_bins: int = 3,
     ):
+        self.keys = ["pitch", "dstart_bin", "duration_bin", "velocity_bin"]
         self.n_dstart_bins = n_dstart_bins
         self.n_duration_bins = n_duration_bins
         self.n_velocity_bins = n_velocity_bins

--- a/quantizers/relative_time_quantizer.py
+++ b/quantizers/relative_time_quantizer.py
@@ -1,7 +1,8 @@
 import yaml
 import numpy as np
 import pandas as pd
-from quantizer import MidiQuantizer
+
+from quantizers.quantizer import MidiQuantizer
 
 
 class RelativeTimeQuantizer(MidiQuantizer):

--- a/quantizers/relative_time_quantizer.py
+++ b/quantizers/relative_time_quantizer.py
@@ -87,8 +87,8 @@ class RelativeTimeQuantizer(MidiQuantizer):
         self.bin_to_velocity = [int(0.8 * self.velocity_bin_edges[1])]
 
         for it in range(2, len(self.velocity_bin_edges)):
-            dstart = (self.velocity_bin_edges[it - 1] + self.velocity_bin_edges[it]) / 2
-            self.bin_to_velocity.append(int(dstart))
+            velocity = (self.velocity_bin_edges[it - 1] + self.velocity_bin_edges[it]) / 2
+            self.bin_to_velocity.append(int(velocity))
 
     def make_vocab(self) -> list[str]:
         vocab = []

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -5,6 +5,7 @@ import streamlit as st
 from quantizer_generator import QuantizerGenerator
 from midi_tokenizers.midi_tokenizer import MidiTokenizer
 from midi_tokenizers.no_loss_tokenizer import NoLossTokenizer
+from midi_tokenizers.one_time_tokenizer import OneTimeTokenizer
 from midi_tokenizers.quantized_midi_tokenizer import QuantizedMidiTokenizer
 
 
@@ -64,11 +65,30 @@ class NoLossTokenizerFactory(TokenizerFactory):
         return NoLossTokenizer(**parameters)
 
 
+class OneTimeTokenizerFactory(TokenizerFactory):
+    tokenizer_desc = """
+    This tokenizer uses a single time token and uses it as many times as it needs.
+
+    Quantizes velocity into `n_velocity_bins` linearly spread bins.
+    """
+
+    @staticmethod
+    def select_parameters() -> dict:
+        eps = st.number_input(label="eps - minimal time shift value", value=0.1, format="%0.3f")
+        n_velocity_bins = st.number_input(label="n_velocity_bins", value=32)
+        return {"eps": eps, "n_velocity_bins": n_velocity_bins}
+
+    @staticmethod
+    def create_tokenizer(parameters: dict) -> NoLossTokenizer:
+        return OneTimeTokenizer(**parameters)
+
+
 class TokenizerGenerator:
     # append new factories to this dict when new Tokenizers are defined.
     name_to_factory_map: dict[str, "TokenizerFactory"] = {
         "QuantizedMidiTokenizer": QuantizedMidiTokenizerFactory(),
         "NoLossTokenizer": NoLossTokenizerFactory(),
+        "OneTimeTokenizer": OneTimeTokenizerFactory(),
     }
 
     def tokenizer_info(self, name: str):

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -49,6 +49,7 @@ class QuantizedMidiTokenizerFactory(TokenizerFactory):
 class NoLossTokenizerFactory(TokenizerFactory):
     tokenizer_desc = """
     This tokenizer uses multiple time tokens, rising exponentialy from `eps` to 2 seconds.
+
     Quantizes velocity into `n_velocity_bins` linearly spread bins.
     """
 

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -5,6 +5,7 @@ import streamlit as st
 from quantizer_generator import QuantizerGenerator
 from midi_tokenizers.midi_tokenizer import MidiTokenizer
 from midi_tokenizers.quantized_midi_tokenizer import QuantizedMidiTokenizer
+from midi_tokenizers.no_loss_tokenizer import NoLossTokenizer
 
 
 class TokenizerFactory:
@@ -32,7 +33,7 @@ class QuantizedMidiTokenizerFactory(TokenizerFactory):
     """
 
     @staticmethod
-    def select_parameters():
+    def select_parameters() -> dict:
         quantizer_generator = QuantizerGenerator()
         quantizer_name = st.selectbox(label="quantizer", options=quantizer_generator.name_to_factory_map.keys())
         factory = quantizer_generator.name_to_factory_map[quantizer_name]
@@ -45,10 +46,26 @@ class QuantizedMidiTokenizerFactory(TokenizerFactory):
         return QuantizedMidiTokenizer(**parameters)
 
 
+class NoLossTokenizerFactory(TokenizerFactory):
+    tokenizer_desc = """
+    This tokenizer uses multiple time tokens, rising exponentialy from `eps` to 2 seconds.
+    """
+
+    @staticmethod
+    def select_parameters() -> dict:
+        eps = st.number_input(label="eps - minimal time shift value", value=0.01, format="%0.3f")
+        return {"eps": eps}
+    
+    @staticmethod
+    def create_tokenizer(parameters: dict) -> NoLossTokenizer:
+        return NoLossTokenizer(**parameters)
+    
+
 class TokenizerGenerator:
     # append new factories to this dict when new Tokenizers are defined.
     name_to_factory_map: dict[str, "TokenizerFactory"] = {
         "QuantizedMidiTokenizer": QuantizedMidiTokenizerFactory(),
+        "NoLossTokenizer": NoLossTokenizerFactory(),
     }
 
     def tokenizer_info(self, name: str):

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -4,8 +4,8 @@ import streamlit as st
 
 from quantizer_generator import QuantizerGenerator
 from midi_tokenizers.midi_tokenizer import MidiTokenizer
-from midi_tokenizers.quantized_midi_tokenizer import QuantizedMidiTokenizer
 from midi_tokenizers.no_loss_tokenizer import NoLossTokenizer
+from midi_tokenizers.quantized_midi_tokenizer import QuantizedMidiTokenizer
 
 
 class TokenizerFactory:
@@ -55,11 +55,11 @@ class NoLossTokenizerFactory(TokenizerFactory):
     def select_parameters() -> dict:
         eps = st.number_input(label="eps - minimal time shift value", value=0.01, format="%0.3f")
         return {"eps": eps}
-    
+
     @staticmethod
     def create_tokenizer(parameters: dict) -> NoLossTokenizer:
         return NoLossTokenizer(**parameters)
-    
+
 
 class TokenizerGenerator:
     # append new factories to this dict when new Tokenizers are defined.

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -74,7 +74,7 @@ class OneTimeTokenizerFactory(TokenizerFactory):
 
     @staticmethod
     def select_parameters() -> dict:
-        eps = st.number_input(label="eps - minimal time shift value", value=0.1, format="%0.3f")
+        eps = st.number_input(label="eps - minimal time shift value", value=0.01, format="%0.3f")
         n_velocity_bins = st.number_input(label="n_velocity_bins", value=32)
         return {"eps": eps, "n_velocity_bins": n_velocity_bins}
 

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -49,12 +49,14 @@ class QuantizedMidiTokenizerFactory(TokenizerFactory):
 class NoLossTokenizerFactory(TokenizerFactory):
     tokenizer_desc = """
     This tokenizer uses multiple time tokens, rising exponentialy from `eps` to 2 seconds.
+    Quantizes velocity into `n_velocity_bins` linearly spread bins.
     """
 
     @staticmethod
     def select_parameters() -> dict:
         eps = st.number_input(label="eps - minimal time shift value", value=0.01, format="%0.3f")
-        return {"eps": eps}
+        n_velocity_bins = st.number_input(label="n_velocity_bins", value=32)
+        return {"eps": eps, "n_velocity_bins": n_velocity_bins}
 
     @staticmethod
     def create_tokenizer(parameters: dict) -> NoLossTokenizer:

--- a/tokenizer_generator.py
+++ b/tokenizer_generator.py
@@ -1,0 +1,65 @@
+from abc import abstractmethod
+
+import streamlit as st
+
+from quantizer_generator import QuantizerGenerator
+from midi_tokenizers.midi_tokenizer import MidiTokenizer
+from midi_tokenizers.quantized_midi_tokenizer import QuantizedMidiTokenizer
+
+
+class TokenizerFactory:
+    """
+    Base class for Quantizer objects factory. Makes adding new Quantizers to the dashboard easier.
+    """
+
+    tokenizer_desc = ""
+
+    @abstractmethod
+    def select_parameters() -> dict:
+        pass
+
+    @abstractmethod
+    def create_tokenizer(parameters: dict) -> MidiTokenizer:
+        pass
+
+
+class QuantizedMidiTokenizerFactory(TokenizerFactory):
+    tokenizer_desc = """
+    Tokenizer that uses MidiQuantizers to first quantize the data into bins,
+    then treat all possible combinations as seperate tokens.
+
+    The tokens are stuctured like "pitch-[start_bin/dstart_bin]-duration_bin-velocity_bin"
+    """
+
+    @staticmethod
+    def select_parameters():
+        quantizer_generator = QuantizerGenerator()
+        quantizer_name = st.selectbox(label="quantizer", options=quantizer_generator.name_to_factory_map.keys())
+        factory = quantizer_generator.name_to_factory_map[quantizer_name]
+        quantization_cfg = factory.select_parameters()
+
+        return {"quantization_cfg": quantization_cfg, "quantizer_name": quantizer_name}
+
+    @staticmethod
+    def create_tokenizer(parameters: dict) -> QuantizedMidiTokenizer:
+        return QuantizedMidiTokenizer(**parameters)
+
+
+class TokenizerGenerator:
+    # append new factories to this dict when new Tokenizers are defined.
+    name_to_factory_map: dict[str, "TokenizerFactory"] = {
+        "QuantizedMidiTokenizer": QuantizedMidiTokenizerFactory(),
+    }
+
+    def tokenizer_info(self, name: str):
+        return self.name_to_factory_map[name].tokenizer_desc
+
+    def generate_tokenizer_with_streamlit(self, name: str) -> MidiTokenizer:
+        factory = self.name_to_factory_map[name]
+        parameters = factory.select_parameters()
+
+        return factory.create_tokenizer(parameters)
+
+    def generate_tokenizer(self, name: str, parameters: dict) -> MidiTokenizer:
+        factory = self.name_to_factory_map[name]
+        return factory.create_tokenizer(parameters)


### PR DESCRIPTION
### MidiTokenizer
Tokenizers for midi data

### QuantizedMidiTokenizer
Tokenizer that uses quantization and produces tokens structured like 
`pitch`-`[dstart_bin/start_bin]`-`duration_bin`-`velocity`

### NoLossTokenizer
It's designed to keep as much detail as possible when converting MIDI events into tokens. You can adjust how finely it slices time using the eps parameter.
Quantizes velocity into linearly distributed `n_velocity_bins` bins.

https://a8cd-46-205-140-240.ngrok-free.app/