### PR TITLE
Extend the base tokenizer interface

### DIFF
--- a/midi_tokenizers/__init__.py
+++ b/midi_tokenizers/__init__.py
@@ -1,3 +1,4 @@
+# TODO Absolute imports are recommended
 from .base_tokenizers.midi_tokenizer import MidiTokenizer
 from .base_tokenizers.one_time_tokenizer import OneTimeTokenizer
 from .midi_trainable_tokenizers.bpe_tokenizer import BpeMidiTokenizer

--- a/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
@@ -206,11 +206,11 @@ class ExponentialTimeTokenizer(MidiTokenizer):
 
         return time_tokens
 
-    def tokenize(self, notes: pd.DataFrame) -> list[str]:
-        notes = self.quantize_frame(notes)
-        notes = notes.sort_values(by="pitch", kind="stable")
-        notes.sort_values(by="start", kind="stable")
-        events = self._notes_to_events(notes)
+    def tokenize(self, notes_df: pd.DataFrame) -> list[str]:
+        notes_df = self.quantize_frame(notes_df)
+        notes_df = notes_df.sort_values(by="pitch", kind="stable")
+        notes_df.sort_values(by="start", kind="stable")
+        events = self._notes_to_events(notes_df)
 
         tokens = []
         previous_time = 0
@@ -268,4 +268,5 @@ class ExponentialTimeTokenizer(MidiTokenizer):
             notes_df.loc[notes_df["end"] == notes_df["start"], "end"] += self.min_time_unit
             notes_df = notes_df.sort_values(by="pitch", kind="stable")
             notes_df = notes_df.sort_values("start", kind="stable").reset_index(drop=True)
+
         return notes_df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "midi_tokenizers"
-version = "2.0"
+version = "2.0.1"
 authors = [
   { name="Wojciech Matejuk", email="wmatejuk14@gmail.com" },
   { name = "EPR Labs", email = "tomek@epr-labs.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "midi_tokenizers"
 version = "2.0"
 authors = [
   { name="Wojciech Matejuk", email="wmatejuk14@gmail.com" },
-  { name = "algrtm", email = "office@algrtm.com" }
+  { name = "EPR Labs", email = "tomek@epr-labs.com" }
 ]
 description = "Package with MIDI tokenizers and quantizers."
 readme = "README.md"

--- a/scripts/test_tokenizer.py
+++ b/scripts/test_tokenizer.py
@@ -32,7 +32,12 @@ def measure_tokenization_speed(tokenizer, midi_pieces):
     total_time = end_time - start_time
     tokens_per_second = total_tokens / total_time
 
-    return total_time, total_tokens, tokens_per_second, tokenized_pieces
+    print("\nTokenization:")
+    print(f"Total time: {total_time:.2f} seconds")
+    print(f"Total tokens: {total_tokens}")
+    print(f"Tokenization speed: {tokens_per_second:.2f} tokens/second")
+
+    return tokenized_pieces
 
 
 # TODO typehints
@@ -50,7 +55,12 @@ def measure_untokenization_speed(tokenizer, tokenized_pieces):
     total_time = end_time - start_time
     tokens_per_second = total_tokens / total_time
 
-    return total_time, total_tokens, tokens_per_second, untokenized_pieces
+    print("\nUntokenization:")
+    print(f"Total time: {total_time:.2f} seconds")
+    print(f"Total tokens: {total_tokens}")
+    print(f"Untokenization speed: {tokens_per_second:.2f} tokens/second")
+
+    return untokenized_pieces
 
 
 def test_tokenizer_accuracy(
@@ -105,24 +115,16 @@ def main():
     print(f"Dataset size: {len(midi_pieces)} records")
 
     # Measure tokenization speed
-    tokenization_time, total_tokens, tokenization_speed, tokenized_pieces = measure_tokenization_speed(
+    tokenized_pieces = measure_tokenization_speed(
         tokenizer=tokenizer,
         midi_pieces=midi_pieces,
     )
-    print("\nTokenization:")
-    print(f"Total time: {tokenization_time:.2f} seconds")
-    print(f"Total tokens: {total_tokens}")
-    print(f"Tokenization speed: {tokenization_speed:.2f} tokens/second")
 
     # Measure untokenization speed
-    untokenization_time, _, untokenization_speed, untokenized_pieces = measure_untokenization_speed(
+    untokenized_pieces = measure_untokenization_speed(
         tokenizer=tokenizer,
         tokenized_pieces=tokenized_pieces,
     )
-    print("\nUntokenization:")
-    print(f"Total time: {untokenization_time:.2f} seconds")
-    print(f"Total tokens: {total_tokens}")
-    print(f"Untokenization speed: {untokenization_speed:.2f} tokens/second")
 
     # Test accuracy
     print("\nTesting accuracy...")

--- a/scripts/test_tokenizer.py
+++ b/scripts/test_tokenizer.py
@@ -8,6 +8,7 @@ from datasets import load_dataset
 from midi_tokenizers.base_tokenizers.exponential_time_tokenizer import ExponentialTimeTokenizer
 
 
+# TODO typehints
 def load_midi_pieces(dataset):
     midi_pieces = []
     for record in dataset:
@@ -16,6 +17,7 @@ def load_midi_pieces(dataset):
     return midi_pieces
 
 
+# TODO typehints
 def measure_tokenization_speed(tokenizer, midi_pieces):
     start_time = time.time()
     total_tokens = 0
@@ -33,6 +35,7 @@ def measure_tokenization_speed(tokenizer, midi_pieces):
     return total_time, total_tokens, tokens_per_second, tokenized_pieces
 
 
+# TODO typehints
 def measure_untokenization_speed(tokenizer, tokenized_pieces):
     start_time = time.time()
     total_tokens = 0
@@ -51,7 +54,9 @@ def measure_untokenization_speed(tokenizer, tokenized_pieces):
 
 
 def test_tokenizer_accuracy(
-    original_pieces: List[MidiPiece], untokenized_pieces: List[pd.DataFrame], tolerance_ms: float = 10
+    original_pieces: List[MidiPiece],
+    untokenized_pieces: List[pd.DataFrame],
+    tolerance_ms: float = 10,
 ) -> dict:
     total_notes = 0
     notes_within_tolerance = 0
@@ -92,20 +97,28 @@ def main():
     tokenizer = ExponentialTimeTokenizer(min_time_unit=0.01, n_velocity_bins=32)
     tokenizer_desc = tokenizer.to_dict()
     tokenizer = ExponentialTimeTokenizer.from_dict(tokenizer_desc=tokenizer_desc)
-    # tokenizer = AwesomeMidiTokenizer.from_file("dumps/awesome_tokenizers/awesome-tokenizer-test-2024-06-11_17-11-44.json")
+    # tokenizer = AwesomeMidiTokenizer.from_file(
+    #     "dumps/awesome_tokenizers/awesome-tokenizer-test-2024-06-11_17-11-44.json",
+    # )
 
     print("\nRunning speed and accuracy test for ExponentialTimeTokenizer on validation split")
     print(f"Dataset size: {len(midi_pieces)} records")
 
     # Measure tokenization speed
-    tokenization_time, total_tokens, tokenization_speed, tokenized_pieces = measure_tokenization_speed(tokenizer, midi_pieces)
+    tokenization_time, total_tokens, tokenization_speed, tokenized_pieces = measure_tokenization_speed(
+        tokenizer=tokenizer,
+        midi_pieces=midi_pieces,
+    )
     print("\nTokenization:")
     print(f"Total time: {tokenization_time:.2f} seconds")
     print(f"Total tokens: {total_tokens}")
     print(f"Tokenization speed: {tokenization_speed:.2f} tokens/second")
 
     # Measure untokenization speed
-    untokenization_time, _, untokenization_speed, untokenized_pieces = measure_untokenization_speed(tokenizer, tokenized_pieces)
+    untokenization_time, _, untokenization_speed, untokenized_pieces = measure_untokenization_speed(
+        tokenizer=tokenizer,
+        tokenized_pieces=tokenized_pieces,
+    )
     print("\nUntokenization:")
     print(f"Total time: {untokenization_time:.2f} seconds")
     print(f"Total tokens: {total_tokens}")


### PR DESCRIPTION
Intended usage with the new interface:

```python
from fortepyan import MidiPiece
from midi_tokenizers import ExponentialTimeTokenizer

piece = MidiPiece.from_file("piano.mid")

special_tokens = ["<BACH>", "<CHOPIN>", "<SLOW>", "<FAST>", "<SOFT>", "<4/4>", "<3/4>", "<BANGER>"]
tokenizer = ExponentialTimeTokenizer(special_tokens=special_tokens)

notes_encoding: list[int] = tokenizer.encode_notes_df(notes_df=piece.df)

# You can use it for example to communicate results of any music information retrieval system you have
piece_description_tokens = ["<BACH>", "<4/4>", "<BANGER>"]
piece_description_encoding: list[int] = tokenizer.encode_tokens(tokens=piano_description_tokens)

# Now you have a sequence of tokens that encapsulates both the music, and meta information you have about it
music_encoding = piece_description_encoding + notes_encoding
```

