### PR TITLE
MIDI-159: Special Placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dumps/*
 *.egg-info
 build/*
 notes.py
+.*

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ import pandas as pd
 from midi_tokenizers import OneTimeTokenizer, ExponentialTimeTokenizer, QuantizedMidiTokenizer
 
 # Sample MIDI data
-data = pd.DataFrame({
+notes_df = pd.DataFrame({
     'pitch': [74, 71, 83, 79, 77],
     'velocity': [92, 110, 103, 92, 89],
     'start': [0.973958, 0.985417, 0.985417, 0.989583, 0.989583],

--- a/dashboards/awesome_tokenizer_review.py
+++ b/dashboards/awesome_tokenizer_review.py
@@ -216,13 +216,15 @@ def main():
     st.write(f"number of tokens: {len(tokens)}")
     with st.expander(label="tokens"):
         st.write(tokens)
-    base_tokens = [
-        [base_tokenizer.vocab[idx] for idx in trainable_midi_tokenizer.awesome_tokens_to_base_ids([token])] for token in tokens
-    ]
+    base_tokens = []
+    for token in tokens:
+        for idx in trainable_midi_tokenizer.awesome_tokens_to_base_ids([token]):
+            base_tokens.append(base_tokenizer.lexicon.vocab[idx])
+
     with st.expander(label="base_tokens"):
         st.write(base_tokens)
     base_vocab = [
-        (token, [base_tokenizer.vocab[idx] for idx in trainable_midi_tokenizer.awesome_tokens_to_base_ids([token])])
+        (token, [base_tokenizer.lexicon[idx] for idx in trainable_midi_tokenizer.awesome_tokens_to_base_ids([token])])
         for token in trainable_midi_tokenizer.vocab[1000:1100]
     ]
     with st.expander(label="base_vocab"):

--- a/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
@@ -295,13 +295,8 @@ class ExponentialTimeTokenizer(MidiTokenizer):
 
     def tokenize(self, notes_df: pd.DataFrame) -> list[str]:
         notes_df = self.quantize_frame(notes_df)
+        notes_df = notes_df.sort_values(by="pitch")
 
-        # TODO Why do we need a "stable" kind? (I'm guessing we don't)
-        notes_df = notes_df.sort_values(by="pitch")  # , kind="stable")
-
-        # FIXME This is not assigned and doesn't do anything ...
-        # Should this overwrite notes_df, or be removed? (I'm guessing removed)
-        # notes_df.sort_values(by="start", kind="stable")
         events = self._notes_to_events(notes_df)
 
         tokens = []

--- a/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
@@ -33,10 +33,20 @@ class ExponentialTimeTokenizer(MidiTokenizer):
 
         self.pad_token_id = self.lexicon.token_to_id["<PAD>"]
 
+    @classmethod
+    def build_tokenizer(cls, tokenizer_config: dict) -> "MidiTokenizer":
+        lexicon = cls._build_lexicon(tokenizer_config=tokenizer_config)
+
+        tokenizer = cls(
+            lexicon=lexicon,
+            tokenizer_config=tokenizer_config,
+        )
+        return tokenizer
+
     def __rich_repr__(self):
         yield "min_time_unit", self.min_time_unit
         yield "vocab_size", self.vocab_size
-        yield "n_placeholder_tokens", self.n_special_ids
+        yield "n_placeholder_tokens", self.n_placeholder_tokens
 
     @property
     def parameters(self):

--- a/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
@@ -9,23 +9,25 @@ class ExponentialTimeTokenizer(MidiTokenizer):
     Tokenizer for MIDI data using exponential time quantization.
 
     Attributes:
-        min_time_unit (float): The minimum time unit for quantizing time.
-        n_velocity_bins (int): The number of velocity bins.
-        special_tokens (list[str]): A list of special tokens.
-        token_to_id (dict): Mapping from tokens to their IDs.
-        velocity_bin_edges (np.ndarray): Edges for velocity bins.
-        bin_to_velocity (list[int]): Mapping from bins to velocity values.
-        name (str): Name of the tokenizer.
+        min_time_unit (float): Minimum time unit for quantization (default: 0.01)
+        n_velocity_bins (int): Number of velocity quantization bins (default: 128)
+        n_special_ids (int): Number of reserved special token IDs (default: 1024)
+        special_tokens (list[str]): Custom special tokens included in vocabulary
+        first_placeholder_token (int): Index where placeholder tokens begin
+        original_vocab_size (int): Size of vocabulary before adding placeholders
+        token_to_id (dict): Maps token strings to their numerical IDs
+        velocity_bin_edges (np.ndarray): Boundaries for velocity quantization bins
+        bin_to_velocity (list[int]): Maps velocity bins back to MIDI velocity values
+        name (str): Tokenizer identifier ("ExponentialTimeTokenizer")
+        step_to_token (dict): Maps quantized time steps to token strings
+        token_to_step (dict): Maps token strings to quantized time steps
+        pad_token_id (int): ID of the padding token
     """
 
     def __init__(
         self,
         min_time_unit: float = 0.01,
         n_velocity_bins: int = 128,
-        # TODO: I would rename this to `n_special_ids` and allow to initialize
-        # with starting special tokens, the rest will be placeholders.
-        # This allows to do ExponentialTimeTokenizer.from_dict(tokenizer.to_dict())
-        # `special_ids` should suggest "special places in the vocab"
         n_special_ids: int = 1024,
         special_tokens: list[str] = None,
     ):
@@ -33,13 +35,15 @@ class ExponentialTimeTokenizer(MidiTokenizer):
         Initialize the ExponentialTimeTokenizer with specified time unit, velocity bins, and special tokens.
 
         Parameters:
-        min_time_unit (float): The minimum time unit for quantizing time. Defaults to 0.001.
-        n_velocity_bins (int): The number of velocity bins. Defaults to 128.
-        special_tokens (list[str]): A list of special tokens. Defaults to None.
+            min_time_unit: Smallest time unit for quantization, in seconds. Determines timing precision.
+            n_velocity_bins: Number of bins for quantizing MIDI velocity values (1-127).
+            n_special_ids: Number of reserved IDs for special tokens and placeholders.
+            special_tokens: List of special token strings to include in vocabulary.
         """
         super().__init__(special_tokens)
         self.min_time_unit = min_time_unit
         self.n_velocity_bins = n_velocity_bins
+        # `special_ids` should suggest "special places in the vocab"
         self.n_special_ids = n_special_ids
 
         # Will be changed in _build_vocab

--- a/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
@@ -206,6 +206,9 @@ class ExponentialTimeTokenizer(MidiTokenizer):
         """
         new_vocab = self.vocab.copy()
         for special_token in special_tokens:
+            if special_token in new_vocab:
+                print(f"Special token already in vocab: {special_token}")
+                continue
             # Switch the placeholder token for a special token
             new_vocab[self.first_placeholder_id] = special_token
             self.first_placeholder_id += 1

--- a/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/exponential_time_tokenizer.py
@@ -42,10 +42,10 @@ class ExponentialTimeTokenizer(MidiTokenizer):
 
         # List the tokens and step sizes describing time, to use during time tokenization
         self.time_tokens = [t for t in self.vocab if t.endswith("T")]
-        self.step_sizes = sorted([self.token_to_value(t) for t in self.time_tokens], reverse=True)
+        self.step_sizes = sorted([ExponentialTimeTokenizer.token_to_value(t) for t in self.time_tokens], reverse=True)
 
     @classmethod
-    def build_tokenizer(cls, tokenizer_config: dict) -> "MidiTokenizer":
+    def build_tokenizer(cls, tokenizer_config: dict) -> "ExponentialTimeTokenizer":
         lexicon = cls._build_lexicon(tokenizer_config=tokenizer_config)
 
         tokenizer = cls(
@@ -174,15 +174,12 @@ class ExponentialTimeTokenizer(MidiTokenizer):
         Args:
             special_tokens (list[str]): New tokens to add
         """
+        new_vocab = self.vocab.copy()
         for special_token in special_tokens:
-            # Remove placeholder definition
-            placeholder_token = self.vocab[self.first_placeholder_id]
-            self.token_to_id.pop(placeholder_token)
-
             # Switch the placeholder token for a special token
-            self.vocab[self.first_placeholder_id] = special_token
-            self.token_to_id[special_token] = self.first_placeholder_id
+            new_vocab[self.first_placeholder_id] = special_token
             self.first_placeholder_id += 1
+        self.vocab = new_vocab
 
     def quantize_frame(self, df: pd.DataFrame):
         """

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -12,7 +12,7 @@ class TokenizerLexicon:
         vocab: All available tokens
         first_placeholder_id: Starting ID for placeholder tokens
         token_to_id: Maps tokens to their numeric IDs
-        token_to_value: Maps tokens to their semantic values (pitch/velocity/time)
+        token_to_value: Maps tokens to their semantic values (pitch/velocity/time steps)
     """
 
     vocab: list[str]

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -14,7 +14,7 @@ class MidiTokenizer:
         special_tokens (list): List of special tokens.
     """
 
-    def __init__(self):
+    def __init__(self, special_tokens: list[str] = None):
         """
         Initializes the MidiTokenizer with optional special tokens.
 
@@ -25,6 +25,7 @@ class MidiTokenizer:
         self.vocab = []
         self.name = "MidiTokenizer"
         self.pad_token_id = 0
+        self.special_tokens = special_tokens if special_tokens else []
 
     @abstractmethod
     def tokenize(self, notes_df: pd.DataFrame) -> list[str]:

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -11,9 +11,7 @@ class MidiTokenizer:
 
     Attributes:
         tokenizer_config (dict): Configuration parameters
-        name (str): Tokenizer identifier
         vocab (list[str]): Vecabulary of the tokenizer
-        token_to_id: (dict[str, int]): mapping of tokens to indieces in the vocab
         pad_token_id (int): ID of padding token
     """
 
@@ -39,7 +37,7 @@ class MidiTokenizer:
 
     def set_vocab(self, new_vocab: list[str]):
         self._vocab = new_vocab
-        self.token_to_id = {token: i for i, token in enumerate(new_vocab)}
+        self.token_to_id = {token: it for it, token in enumerate(new_vocab)}
 
     @classmethod
     @abstractmethod

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -10,16 +10,16 @@ class MidiTokenizer:
     and encoding schemes.
 
     Attributes:
-        lexicon (TokenizerLexicon): Contains vocab, ids and value mappings
         tokenizer_config (dict): Configuration parameters
         name (str): Tokenizer identifier
+        vocab (list[str]): Vecabulary of the tokenizer
+        token_to_id: (dict[str, int]): mapping of tokens to indieces in the vocab
         pad_token_id (int): ID of padding token
     """
 
     def __init__(
         self,
         vocab: list[str],
-        first_placeholder_id: int,
         tokenizer_config: dict,
     ):
         """Initialize tokenizer with vocabulary and configuration.
@@ -29,7 +29,6 @@ class MidiTokenizer:
         """
         self.vocab = vocab
         self.token_to_id = {token: it for it, token in enumerate(vocab)}
-        self.first_placeholder_id = first_placeholder_id
 
         self.tokenizer_config = tokenizer_config
         self.name = "MidiTokenizer"
@@ -45,22 +44,6 @@ class MidiTokenizer:
     @abstractmethod
     def _build_lexicon(cls, tokenizer_config: dict) -> dict:
         pass
-
-    def add_special_tokens(self, special_tokens: list[str]):
-        """Add custom tokens by replacing placeholders.
-
-        Args:
-            special_tokens (list[str]): New tokens to add
-        """
-        for special_token in special_tokens:
-            # Remove placeholder definition
-            placeholder_token = self.vocab[self.first_placeholder_id]
-            self.token_to_id.pop(placeholder_token)
-
-            # Switch the placeholder token for a special token
-            self.vocab[self.first_placeholder_id] = special_token
-            self.token_to_id[special_token] = self.first_placeholder_id
-            self.first_placeholder_id += 1
 
     @abstractmethod
     def tokenize(self, notes_df: pd.DataFrame) -> list[str]:

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -27,10 +27,9 @@ class MidiTokenizer:
         Args:
             tokenizer_config (dict[str, Any]): Args defining tokenization behavior
         """
-        self.vocab = vocab
+        self.set_vocab(vocab)
 
         self.tokenizer_config = tokenizer_config
-        self.name = "MidiTokenizer"
 
         self.pad_token_id = self.token_to_id["<PAD>"]
 
@@ -38,19 +37,13 @@ class MidiTokenizer:
     def vocab(self) -> list[str]:
         return self._vocab
 
-    @vocab.setter
-    def vocab(self, new_vocab: list[str]):
+    def set_vocab(self, new_vocab: list[str]):
         self._vocab = new_vocab
         self.token_to_id = {token: i for i, token in enumerate(new_vocab)}
 
     @classmethod
     @abstractmethod
     def build_tokenizer(cls, tokenizer_config: dict) -> "MidiTokenizer":
-        pass
-
-    @classmethod
-    @abstractmethod
-    def _build_lexicon(cls, tokenizer_config: dict) -> dict:
         pass
 
     @abstractmethod
@@ -91,7 +84,7 @@ class MidiTokenizer:
 
     @property
     def vocab_size(self) -> int:
-        return len(self.lexicon.vocab)
+        return len(self.vocab)
 
     def decode(self, token_ids: list[int]) -> pd.DataFrame:
         """
@@ -103,7 +96,7 @@ class MidiTokenizer:
         Returns:
             pd.DataFrame: DataFrame representation of the decoded tokens.
         """
-        tokens = [self.lexicon.vocab[token_id] for token_id in token_ids]
+        tokens = [self.vocab[token_id] for token_id in token_ids]
         notes_df = self.untokenize(tokens)
 
         return notes_df
@@ -156,4 +149,5 @@ class MidiTokenizer:
         return cls(**tokenizer_desc["parameters"])
 
     def to_dict(self) -> dict:
-        return {"name": self.name, "parameters": self.parameters}
+        name = self.__class__.__name__
+        return {"name": name, "parameters": self.parameters}

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -14,7 +14,7 @@ class MidiTokenizer:
         special_tokens (list): List of special tokens.
     """
 
-    def __init__(self, special_tokens: list[str] = None):
+    def __init__(self):
         """
         Initializes the MidiTokenizer with optional special tokens.
 
@@ -24,9 +24,6 @@ class MidiTokenizer:
         self.token_to_id = None
         self.vocab = []
         self.name = "MidiTokenizer"
-        self.special_tokens = special_tokens
-        if self.special_tokens is None:
-            self.special_tokens = ["<PAD>", "<CLS>"]
         self.pad_token_id = 0
 
     @abstractmethod

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -1,39 +1,92 @@
 from abc import abstractmethod
+from dataclasses import dataclass
 
 import pandas as pd
 
 
-class MidiTokenizer:
-    """
-    Base class for MIDI tokenizers.
+@dataclass
+class TokenizerLexicon:
+    """Storage for tokenizer's vocabulary and mappings.
 
     Attributes:
-        token_to_id (dict): Mapping from tokens to their corresponding IDs.
-        vocab (list): List of tokens in the vocabulary.
-        name (str): Name of the tokenizer.
-        special_tokens (list): List of special tokens.
+        vocab: All available tokens
+        first_placeholder_id: Starting ID for placeholder tokens
+        token_to_id: Maps tokens to their numeric IDs
+        token_to_value: Maps tokens to their semantic values (pitch/velocity/time)
     """
 
-    def __init__(self, special_tokens: list[str] = None):
-        """
-        Initializes the MidiTokenizer with optional special tokens.
+    vocab: list[str]
+    first_placeholder_id: int
+    token_to_id: dict[str, int]
+    token_to_value: int
 
-        Parameters:
-            special_tokens (list[str], optional): List of special tokens. Defaults to None.
+
+class MidiTokenizer:
+    """Base class for MIDI tokenization.
+
+    Handles conversion between MIDI data and token sequences using configurable vocabulary
+    and encoding schemes.
+
+    Attributes:
+        lexicon (TokenizerLexicon): Contains vocab, ids and value mappings
+        tokenizer_config (dict): Configuration parameters
+        name (str): Tokenizer identifier
+        pad_token_id (int): ID of padding token
+    """
+
+    def __init__(self, lexicon: TokenizerLexicon, tokenizer_config: dict):
+        """Initialize tokenizer with vocabulary and configuration.
+
+        Args:
+            lexicon (TokenizerLexicon): Contains vocabulary, token/ID mappings and placeholder info
+            tokenizer_config (dict[str, Any]): Args defining tokenization behavior
         """
         self.token_to_id = None
-        self.vocab = []
+        self.lexicon = lexicon
+        self.tokenizer_config = tokenizer_config
         self.name = "MidiTokenizer"
-        self.pad_token_id = 0
-        self.special_tokens = special_tokens if special_tokens else []
+        self.pad_token_id = lexicon.vocab.index("<PAD>")
+
+    @classmethod
+    def build_tokenizer(cls, tokenizer_config: dict) -> "MidiTokenizer":
+        print(cls)
+        lexicon = cls._build_lexicon(tokenizer_config=tokenizer_config)
+
+        tokenizer = cls(
+            lexicon=lexicon,
+            tokenizer_config=tokenizer_config,
+        )
+        return tokenizer
+
+    # Each tokenizer can have its own way of building vocab
+    @classmethod
+    @abstractmethod
+    def _build_lexicon(cls, tokenizer_config: dict) -> TokenizerLexicon:
+        pass
+
+    def add_special_tokens(self, special_tokens: list[str]):
+        """Add custom tokens by replacing placeholders.
+
+        Args:
+            special_tokens (list[str]): New tokens to add
+        """
+        for special_token in special_tokens:
+            # Remove placeholder definition
+            placeholder_token = self.lexicon.vocab[self.lexicon.first_placeholder_id]
+            self.lexicon.token_to_id.pop(placeholder_token)
+
+            # Switch the placeholder token for a special token
+            self.lexicon.vocab[self.lexicon.first_placeholder_id] = special_token
+            self.lexicon.token_to_id[special_token] = self.lexicon.first_placeholder_id
+            self.lexicon.first_placeholder_id += 1
 
     @abstractmethod
     def tokenize(self, notes_df: pd.DataFrame) -> list[str]:
         """
         Abstract method to tokenize a record.
 
-        Parameters:
-            TODO: Please ALWAYS write consistent abstract methods and documentation
+        Args:
+            notes_df: DataFrame with columns [start, end, pitch, velocity]
 
         Returns:
             list[str]: List of tokens.
@@ -48,7 +101,7 @@ class MidiTokenizer:
         """
         Abstract method to untokenize a list of tokens.
 
-        Parameters:
+        Args:
             tokens (list[str]): The list of tokens to untokenize.
 
         Returns:
@@ -65,19 +118,19 @@ class MidiTokenizer:
 
     @property
     def vocab_size(self) -> int:
-        return len(self.vocab)
+        return len(self.lexicon.vocab)
 
     def decode(self, token_ids: list[int]) -> pd.DataFrame:
         """
         Decodes a list of token IDs into a DataFrame.
 
-        Parameters:
+        Args:
             token_ids (list[int]): List of token IDs to decode.
 
         Returns:
             pd.DataFrame: DataFrame representation of the decoded tokens.
         """
-        tokens = [self.vocab[token_id] for token_id in token_ids]
+        tokens = [self.lexicon.vocab[token_id] for token_id in token_ids]
         notes_df = self.untokenize(tokens)
 
         return notes_df

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -27,8 +27,7 @@ class MidiTokenizer:
         Args:
             tokenizer_config (dict[str, Any]): Args defining tokenization behavior
         """
-        self._vocab = vocab
-        self.vocab = self._vocab
+        self.vocab = vocab
 
         self.tokenizer_config = tokenizer_config
         self.name = "MidiTokenizer"

--- a/midi_tokenizers/base_tokenizers/midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/midi_tokenizer.py
@@ -27,13 +27,22 @@ class MidiTokenizer:
         Args:
             tokenizer_config (dict[str, Any]): Args defining tokenization behavior
         """
-        self.vocab = vocab
-        self.token_to_id = {token: it for it, token in enumerate(vocab)}
+        self._vocab = vocab
+        self.vocab = self._vocab
 
         self.tokenizer_config = tokenizer_config
         self.name = "MidiTokenizer"
 
         self.pad_token_id = self.token_to_id["<PAD>"]
+
+    @property
+    def vocab(self) -> list[str]:
+        return self._vocab
+
+    @vocab.setter
+    def vocab(self, new_vocab: list[str]):
+        self._vocab = new_vocab
+        self.token_to_id = {token: i for i, token in enumerate(new_vocab)}
 
     @classmethod
     @abstractmethod

--- a/midi_tokenizers/base_tokenizers/quantized_midi_tokenizer.py
+++ b/midi_tokenizers/base_tokenizers/quantized_midi_tokenizer.py
@@ -51,7 +51,7 @@ class QuantizedMidiTokenizer(MidiTokenizer):
         self.vocab = list(self.special_tokens)
 
         # add midi tokens to vocab
-        self._build_vocab()
+        self._build_lexicon()
         self.token_to_id = {token: it for it, token in enumerate(self.vocab)}
         self.name = "QuantizedMidiTokenizer"
         self.pad_token_id = self.token_to_id["<PAD>"]
@@ -68,7 +68,7 @@ class QuantizedMidiTokenizer(MidiTokenizer):
     def parameters(self):
         return {"quantization_cfg": self.quantization_cfg, "quantizer_name": self.quantizer_name}
 
-    def _build_vocab(self):
+    def _build_lexicon(self):
         """
         Build the vocabulary of the QuantizedMidiTokenizer,
         including all possible combinations of quantized pitch, dstart, duration, and velocity values.

--- a/midi_tokenizers/midi_trainable_tokenizers/awesome_midi_tokenzier.py
+++ b/midi_tokenizers/midi_trainable_tokenizers/awesome_midi_tokenzier.py
@@ -7,7 +7,7 @@ from tokenizers import Tokenizer, models, trainers, pre_tokenizers
 
 from midi_tokenizers.base_tokenizers.midi_tokenizer import MidiTokenizer
 from midi_tokenizers.midi_trainable_tokenizers.trainable_tokenizer import MidiTrainableTokenizer
-from midi_tokenizers.midi_tokenizers_generation.base_tokenizer_generator import generate_tokenizer as generate_base_tokenizer
+import midi_tokenizers.midi_tokenizers_generation.base_tokenizer_generator as base_tokenizer_generator
 
 
 class AwesomeMidiTokenizer(MidiTrainableTokenizer):
@@ -178,7 +178,7 @@ class AwesomeMidiTokenizer(MidiTrainableTokenizer):
             pd.DataFrame: DataFrame of untokenized MIDI notes.
         """
         base_token_ids = self.awesome_tokens_to_base_ids(tokens)
-        base_tokens = [self.base_tokenizer.vocab[base_token_id] for base_token_id in base_token_ids]
+        base_tokens = [self.base_tokenizer.lexicon[base_token_id] for base_token_id in base_token_ids]
         return self.base_tokenizer.untokenize(tokens=base_tokens)
 
     def to_dict(self):
@@ -206,7 +206,10 @@ class AwesomeMidiTokenizer(MidiTrainableTokenizer):
         parameters = tokenizer_desc["base_tokenizer_parameters"]
         bpe_tokenizer_json = tokenizer_desc["bpe_tokenizer"]
 
-        base_tokenizer = generate_base_tokenizer(name=base_tokenizer_name, parameters=parameters)
+        base_tokenizer = base_tokenizer_generator.generate_tokenizer(
+            name=base_tokenizer_name,
+            parameters=parameters,
+        )
         tokenizer = Tokenizer.from_str(bpe_tokenizer_json)
         return cls(base_tokenizer=base_tokenizer, bpe_tokenizer=tokenizer)
 

--- a/midi_tokenizers/midi_trainable_tokenizers/awesome_midi_tokenzier.py
+++ b/midi_tokenizers/midi_trainable_tokenizers/awesome_midi_tokenzier.py
@@ -178,7 +178,7 @@ class AwesomeMidiTokenizer(MidiTrainableTokenizer):
             pd.DataFrame: DataFrame of untokenized MIDI notes.
         """
         base_token_ids = self.awesome_tokens_to_base_ids(tokens)
-        base_tokens = [self.base_tokenizer.lexicon[base_token_id] for base_token_id in base_token_ids]
+        base_tokens = [self.base_tokenizer.vocab[base_token_id] for base_token_id in base_token_ids]
         return self.base_tokenizer.untokenize(tokens=base_tokens)
 
     def to_dict(self):
@@ -206,7 +206,7 @@ class AwesomeMidiTokenizer(MidiTrainableTokenizer):
         parameters = tokenizer_desc["base_tokenizer_parameters"]
         bpe_tokenizer_json = tokenizer_desc["bpe_tokenizer"]
 
-        base_tokenizer = base_tokenizer_generator.generate_tokenizer(
+        base_tokenizer = base_tokenizer_generator.generate_base_tokenizer(
             name=base_tokenizer_name,
             parameters=parameters,
         )

--- a/midi_tokenizers/midi_trainable_tokenizers/trainable_tokenizer.py
+++ b/midi_tokenizers/midi_trainable_tokenizers/trainable_tokenizer.py
@@ -5,71 +5,90 @@ from abc import abstractmethod
 from datasets import Dataset
 from tokenizers import Tokenizer, trainers
 
-from midi_tokenizers.base_tokenizers.midi_tokenizer import MidiTokenizer, TokenizerLexicon
+from midi_tokenizers.base_tokenizers.midi_tokenizer import MidiTokenizer
 
 
 class MidiTrainableTokenizer(MidiTokenizer):
-    """Base class for trainable MIDI tokenizers with HuggingFace integration."""
+    """
+    Base class for trainable MIDI tokenizers.
 
-    def __init__(
-        self,
-        lexicon: TokenizerLexicon,
-        tokenizer_config: dict,
-        base_tokenizer: MidiTokenizer = None,
-        text_tokenizer: Tokenizer = None,
-        trainer: trainers.Trainer = None,
-    ):
-        super().__init__(lexicon=lexicon, tokenizer_config=tokenizer_config)
-        self.base_tokenizer = base_tokenizer
-        self.text_tokenizer = text_tokenizer
-        self.trainer = trainer
+    Inherits from MidiTokenizer and adds functionality for training the tokenizer.
 
-    @property
-    def parameters(self):
-        return {
-            "lexicon": self.lexicon,
-            "tokenizer_config": self.tokenizer_config,
-            "base_tokenizer": self.base_tokenizer,
-            "text_tokenizer": self.text_tokenizer,
-            "trainer": self.trainer,
-        }
+    Attributes:
+        base_tokenizer (MidiTokenizer): The base tokenizer used for generating initial tokens.
+        text_tokenizer (Tokenizer): The text tokenizer used for training.
+        trainer (trainers.Trainer): The trainer used for training the text tokenizer.
+    """
+
+    def __init__(self, special_tokens: list[str] = None):
+        """
+        Initialize the MidiTrainableTokenizer with optional special tokens.
+
+        Parameters:
+            special_tokens (list[str], optional): List of special tokens. Defaults to None.
+        """
+        super().__init__(special_tokens=special_tokens)
+        self.base_tokenizer: MidiTokenizer = None
+        self.text_tokenizer: Tokenizer = None
+        self.trainer: trainers.Trainer = None
 
     @abstractmethod
-    def prepare_data_for_training(self, file_name: str, train_dataset: Dataset):
-        """Prepare dataset for training text tokenizer.
+    def prepare_data_for_training(file_name: str, train_dataset: Dataset):
+        """
+        Abstract method to prepare data for training.
 
-        Args:
-            file_name: Output file path
-            train_dataset: Source dataset
+        This method should be implemented by subclasses to specify how the training data
+        should be prepared and written to a file.
+
+        Parameters:
+            file_name (str): The name of the file to write the prepared data.
+            train_dataset (Dataset): The dataset to prepare for training.
         """
         pass
 
     def train(self, train_dataset: Dataset):
-        """Train tokenizer on dataset."""
+        """
+        Train the tokenizer using the provided training dataset.
+
+        Parameters:
+            train_dataset (Dataset): The dataset to use for training.
+        """
         file = "tmp_dump.txt"
+        # create an empy file
         open(file, "w").close()
         try:
-            self.prepare_data_for_training(file, train_dataset)
+            self.prepare_data_for_training(file_name=file, train_dataset=train_dataset)
+
             self.text_tokenizer.train([file], trainer=self.trainer)
-            self._update_vocab()
+            # Initialize token-to-ID mapping - huggingface vocab is like our token_to_id
+            self.token_to_id = self.text_tokenizer.get_vocab()
+            self.vocab = [token for token, it in self.token_to_id.items()]
         finally:
+            # make sure to always clean up
             os.unlink(file)
 
     def train_from_text_dataset(self, dataset: Iterable):
-        """Train directly from text dataset."""
-        self.text_tokenizer.train_from_iterator(dataset, trainer=self.trainer)
-        self._update_vocab()
+        """
+        Train the tokenizer directly from a text dataset.
 
-    def _update_vocab(self):
-        """Update internal vocab from trained text tokenizer."""
-        self.lexicon.token_to_id = self.text_tokenizer.get_vocab()
-        self.lexicon.vocab = [token for token in self.lexicon.token_to_id]
+        Parameters:
+            dataset (Iterable): An iterable of text data to use for training.
+        """
+        self.text_tokenizer.train_from_iterator(dataset, trainer=self.trainer)
+
+        # Initialize token-to-ID mapping - huggingface vocab is like our token_to_id
+        self.token_to_id = self.text_tokenizer.get_vocab()
+        self.vocab = [token for token, it in self.token_to_id.items()]
 
     @abstractmethod
     def save_tokenizer(self, path: str):
-        """Save tokenizer state to disk.
+        """
+        Abstract method to save the tokenizer to a specified path.
 
-        Args:
-            path: Save location
+        This method should be implemented by subclasses to specify how the tokenizer
+        should be saved to disk.
+
+        Parameters:
+            path (str): The path to save the tokenizer.
         """
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "midi_tokenizers"
-version = "3.0"
+version = "2.1.0"
 authors = [
   { name="Wojciech Matejuk", email="wmatejuk14@gmail.com" },
   { name = "EPR Labs", email = "tomek@epr-labs.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "midi_tokenizers"
-version = "2.0.1"
+version = "3.0"
 authors = [
   { name="Wojciech Matejuk", email="wmatejuk14@gmail.com" },
   { name = "EPR Labs", email = "tomek@epr-labs.com" }

--- a/scripts/test_tokenizer.py
+++ b/scripts/test_tokenizer.py
@@ -94,45 +94,44 @@ def test_tokenizer_accuracy(
 
 
 def main():
-    # Load the dataset
     dataset = load_dataset("roszcz/maestro-sustain-v2", split="validation")
 
     print("Loading MidiPieces...")
-    loading_start_time = time.time()
+    loading_start = time.time()
     midi_pieces = load_midi_pieces(dataset)
-    loading_end_time = time.time()
-    loading_time = loading_end_time - loading_start_time
-    print(f"MidiPieces loaded in {loading_time:.2f} seconds")
+    print(f"MidiPieces loaded in {time.time() - loading_start:.2f} seconds")
 
-    tokenizer = ExponentialTimeTokenizer(min_time_unit=0.01, n_velocity_bins=32)
+    # Initialize tokenizer with proper config
+    tokenizer = ExponentialTimeTokenizer.build_tokenizer(
+        tokenizer_config={
+            "min_time_unit": 0.01,
+            "n_velocity_bins": 32,
+            "n_special_ids": 1024,
+        }
+    )
+
+    # Test serialization/deserialization
     tokenizer_desc = tokenizer.to_dict()
-    tokenizer = ExponentialTimeTokenizer.from_dict(tokenizer_desc=tokenizer_desc)
-    # tokenizer = AwesomeMidiTokenizer.from_file(
-    #     "dumps/awesome_tokenizers/awesome-tokenizer-test-2024-06-11_17-11-44.json",
-    # )
+    tokenizer = ExponentialTimeTokenizer.from_dict(tokenizer_desc)
 
-    print("\nRunning speed and accuracy test for ExponentialTimeTokenizer on validation split")
-    print(f"Dataset size: {len(midi_pieces)} records")
+    print(f"\nTesting ExponentialTimeTokenizer on {len(midi_pieces)} records")
 
-    # Measure tokenization speed
     tokenized_pieces = measure_tokenization_speed(
         tokenizer=tokenizer,
         midi_pieces=midi_pieces,
     )
 
-    # Measure untokenization speed
     untokenized_pieces = measure_untokenization_speed(
         tokenizer=tokenizer,
         tokenized_pieces=tokenized_pieces,
     )
-
-    # Test accuracy
+    print(midi_pieces[0].df, untokenized_pieces[0])
     print("\nTesting accuracy...")
-    accuracy_results = test_tokenizer_accuracy(midi_pieces, untokenized_pieces)
-    print(f"Total notes: {accuracy_results['total_notes']}")
-    print(f"Notes within 10ms tolerance: {accuracy_results['notes_within_tolerance']}")
-    print(f"Percentage within tolerance: {accuracy_results['percentage_within_tolerance']:.2f}%")
-    print(f"Max absolute error: {accuracy_results['max_error_ms']:.2f}ms")
+    results = test_tokenizer_accuracy(midi_pieces, untokenized_pieces)
+    print(f"Total notes: {results['total_notes']}")
+    print(f"Notes within 10ms: {results['notes_within_tolerance']}")
+    print(f"Accuracy: {results['percentage_within_tolerance']:.2f}%")
+    print(f"Max error: {results['max_error_ms']:.2f}ms")
 
 
 if __name__ == "__main__":

--- a/scripts/test_tokenizer.py
+++ b/scripts/test_tokenizer.py
@@ -104,7 +104,8 @@ def main():
     # Initialize tokenizer with proper config
     tokenizer = ExponentialTimeTokenizer.build_tokenizer(
         tokenizer_config={
-            "min_time_unit": 0.01,
+            "time_unit": 0.01,
+            "max_time_step": 1.0,
             "n_velocity_bins": 32,
             "n_special_ids": 1024,
         }


### PR DESCRIPTION
# New method of adding special tokens to tokenizer
```py
from midi_tokenizers.base_tokenizers import ExponentialTimeTokenizer

tokenizer = ExponentialTimeTokenizer.build_tokenizer(
    tokenizer_config={
        "time_unit": 0.01,
        "max_time_step": 1.0,
        "n_special_ids": 16, 
        "n_velocity_bins": 32
    }
)

special_tokens = ["<special_1>", "<special_2>"]
tokenizer.add_special_tokens(special_tokens=special_tokens)
recreated_tokenizer = tokenizer.from_dict(tokenizer.to_dict())

some_tokens = ['<special_1>', '<special_2>', 'NOTE_ON_55']
encoded_a = tokenizer.encode_tokens(some_tokens)

encoded_b = recreated_tokenizer.encode_tokens(some_tokens)

print(encoded_a == encoded_b)
```
## Changes in vocabulary structure
`"<PAD>"` and  `"<CLS>"` are now always at the beginning of the tokenizer, and other special and placeholder tokens are after the tokens that describe musical pieces (after time tokens). 
